### PR TITLE
Add wind_max_speed to sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ sensor:
       - snow
       - visibility
       - wind_speed
+      - wind_max_speed
       - wind_bearing
 ```
 

--- a/custom_components/aemet/AemetApi/__init__.py
+++ b/custom_components/aemet/AemetApi/__init__.py
@@ -23,7 +23,27 @@ ATTR_STATION_NAME = 'station_name'
 ATTR_WEATHER_PRECIPITATION = 'precipitation'
 ATTR_WEATHER_SNOW = 'snow'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
+ATTR_WEATHER_WIND_MAX_SPEED = 'wind_max_speed'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
+
+ATTR_MAPPINGS = {
+    ATTR_LONGITUDE: 'lon',
+    ATTR_LATITUDE: 'lat',
+    ATTR_ELEVATION: 'alt',
+    ATTR_STATION_NAME: 'ubi',
+    ATTR_WEATHER_PRECIPITATION: 'prec',
+    ATTR_WEATHER_PRESSURE: 'pres',
+    ATTR_WEATHER_TEMPERATURE: 'ta',
+    ATTR_WEATHER_HUMIDITY: 'hr',
+    ATTR_LAST_UPDATE: 'fint',
+    ATTR_WEATHER_VISIBILITY: 'vis',
+    ATTR_WEATHER_SNOW: 'nieve',
+    ATTR_WEATHER_WIND_SPEED: 'vv',
+    ATTR_WEATHER_WIND_MAX_SPEED: 'vmax',
+    ATTR_WEATHER_WIND_BEARING: 'dv'
+}
+
+MS_TO_KMH_ATTRS = [ATTR_WEATHER_WIND_SPEED, ATTR_WEATHER_WIND_MAX_SPEED]
 
 CONF_ATTRIBUTION = 'Data provided by AEMET'
 CONF_STATION_ID = 'station_id'
@@ -72,32 +92,12 @@ class AemetApi:
     def set_data(self, record):
         """Set data using the last record from API."""
         state = {}
-        if 'lon' in record:
-            state[ATTR_LONGITUDE] = record['lon']
-        if 'lat' in record:
-            state[ATTR_LATITUDE] = record['lat']
-        if 'alt' in record:
-            state[ATTR_ELEVATION] = record['alt']
-        if 'ubi' in record:
-            state[ATTR_STATION_NAME] = record['ubi']
-        if 'prec' in record:
-            state[ATTR_WEATHER_PRECIPITATION] = record['prec']
-        if 'pres' in record:
-            state[ATTR_WEATHER_PRESSURE] = record['pres']
-        if 'ta' in record:
-            state[ATTR_WEATHER_TEMPERATURE] = record['ta']
-        if 'hr' in record:
-            state[ATTR_WEATHER_HUMIDITY] = record['hr']
-        if 'fint' in record:
-            state[ATTR_LAST_UPDATE] = record['fint']
-        if 'vis' in record:
-            state[ATTR_WEATHER_VISIBILITY] = record['vis']
-        if 'nieve' in record:
-            state[ATTR_WEATHER_SNOW] = record['nieve']
-        if 'vv' in record:
-            state[ATTR_WEATHER_WIND_SPEED] = record['vv'] * 3.6 # m/s to km/h
-        if 'dv' in record:
-            state[ATTR_WEATHER_WIND_BEARING] = record['dv']
+        for attr_name, attr_value in ATTR_MAPPINGS.items():
+            if attr_value in record:
+                state[attr_name] = record[attr_value]
+        for attr in MS_TO_KMH_ATTRS:
+            if attr in state:
+                state[attr] = round(state[attr] * 3.6, 1) # m/s to km/h
         self.data = state
 
     def get_data(self, variable):

--- a/custom_components/aemet/sensor.py
+++ b/custom_components/aemet/sensor.py
@@ -38,6 +38,7 @@ from .AemetApi import (
     ATTR_WEATHER_PRECIPITATION, 
     ATTR_WEATHER_SNOW, 
     ATTR_WEATHER_WIND_SPEED, 
+    ATTR_WEATHER_WIND_MAX_SPEED, 
     ATTR_WEATHER_WIND_BEARING,
     CONF_ATTRIBUTION, 
     CONF_STATION_ID,
@@ -52,7 +53,8 @@ SENSOR_TYPES = {
     ATTR_WEATHER_PRECIPITATION: ['Precipitation', 'mm', 'mdi:weather-pouring'],
     ATTR_WEATHER_SNOW: ['Snow', LENGTH_CENTIMETERS, 'mdi:snowflake'],
     ATTR_WEATHER_VISIBILITY: ['Visibility', LENGTH_KILOMETERS, 'mdi:eye'],
-    ATTR_WEATHER_WIND_SPEED: ['Wind speed', 'm/s', 'mdi:weather-windy'],
+    ATTR_WEATHER_WIND_SPEED: ['Wind speed', 'km/h', 'mdi:weather-windy'],
+    ATTR_WEATHER_WIND_MAX_SPEED: ['Wind max speed', 'km/h', 'mdi:weather-windy'],
     ATTR_WEATHER_WIND_BEARING: ['Wind bearing', 'degrees', 'mdi:compass'],
 }
 

--- a/info.md
+++ b/info.md
@@ -23,6 +23,7 @@ sensor:
       - snow
       - visibility
       - wind_speed
+      - wind_max_speed
       - wind_bearing
 ```
 


### PR DESCRIPTION
I have added the wind_max_speed because it's a data that I usually want to know about.

I've done some changes on the API side:
* Try to clean field reading (it's an idea, can be reverted, of course):
  * Create attribute mapping for mapping attributes to keys from AEMET
  * Create a list of field to be transformed from m/s to km/h
* Round the decimals to 1 after transforming them to km/h (like in AEMET API results), to avoid floating point precision issues (https://docs.python.org/3/tutorial/floatingpoint.html)
* Add the new field _vmax_ to get the _wind_max_speed_

I've taken advantage to fix the measure unit of wind_speed from m/s to km/h too. The problem is that in the history, it continues to appear in m/s even thoug it captures new data in km/h (in badges it appears correctly). I know how to fix that, but I don't know what is the _cleanest_ way to achieve it.

PS: thanks for your time and for sharing this addon!
