### PR TITLE
Fixes api key too short error

### DIFF
--- a/custom_components/aemet/AemetApi/__init__.py
+++ b/custom_components/aemet/AemetApi/__init__.py
@@ -1,9 +1,20 @@
 import requests
+import urllib3
 from datetime import timedelta
 from logging import getLogger
 from homeassistant.util import Throttle
 
 _LOGGER = getLogger(__name__)
+
+requests.packages.urllib3.disable_warnings()
+requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ":HIGH:!DH:!aNULL"
+try:
+    requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += (
+        ":HIGH:!DH:!aNULL"
+    )
+except AttributeError:
+    # no pyopenssl support used / needed / available
+    pass
 
 from homeassistant.components.weather import (
     ATTR_WEATHER_HUMIDITY, 


### PR DESCRIPTION
Fixes api key too short error: Caused by SSLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1123)'))

Thanks to @dave-code-ruiz as he pointed the solution in this comment: https://github.com/outon/HomeAssistant-AEMET/issues/1#issuecomment-527836834